### PR TITLE
fix(sidebar): handle invalid navigation items gracefully

### DIFF
--- a/app/components/SidebarNavigation.vue
+++ b/app/components/SidebarNavigation.vue
@@ -28,7 +28,7 @@ const buttonPosition = computed(() =>
 )
 
 const groupedItems = computed(() => ({
-  start: items.value.filter(item => (item.position || 'start') === 'start'),
+  start: items.value.filter(item => item.position === 'start'),
   end: items.value.filter(item => item.position === 'end'),
 }))
 

--- a/app/composables/useSidebarItems.js
+++ b/app/composables/useSidebarItems.js
@@ -17,9 +17,11 @@ export function useSidebarItems() {
   }
 
   function processItem(item) {
-    const newItem = { ...item }
+    if (!item.label && !item.icon) {
+      return null
+    }
 
-    newItem.position = item.position || 'start'
+    const newItem = { ...item, position: item.position || 'start' }
 
     if (item.label) {
       newItem.label = translateLabel(item.label)
@@ -29,8 +31,13 @@ export function useSidebarItems() {
       newItem.to = localizePath(item.to)
     }
 
-    if (Array.isArray(item.children) && item.children.length > 0) {
-      newItem.children = item.children.map(child => processItem(child))
+    if (Array.isArray(item.children)) {
+      newItem.children = item.children.map(processItem).filter(Boolean)
+
+      // Si después de procesar, no quedan children y tampoco tiene un `to` o `href`, eliminamos el elemento
+      // if (!newItem.children.length && !newItem.to && !newItem.href) {
+      //   return null
+      // }
     }
 
     return newItem
@@ -38,6 +45,7 @@ export function useSidebarItems() {
 
   return computed(() => {
     const baseItems = appConfig?.sidebar?.navigation?.items || []
-    return baseItems.map(item => processItem(item))
+
+    return baseItems.map(processItem).filter(Boolean)
   })
 }


### PR DESCRIPTION
- Add validation for sidebar items to exclude those without `label` or `icon`.
- Update children processing to filter out invalid items and ensure the final output only contains valid data.
- Improve robustness of sidebar navigation rendering by filtering out empty or misplaced items.